### PR TITLE
캐시 히트 개선

### DIFF
--- a/src/translationService.ts
+++ b/src/translationService.ts
@@ -34,7 +34,7 @@ export class TranslationService {
    * 1. 로컬 사전 → 2. MyMemory → 3. Google Translate → 4. LibreTranslate 순으로 시도
    */
   async translate(text: string): Promise<string> {
-    
+    text = text.toLowerCase();
     // 캐시 확인
     if (this.cache.has(text)) {
       console.log(`Cache hit: "${text}" → "${this.cache.get(text)}"`);


### PR DESCRIPTION
`The`, `the` 등 같은 글자도 대/소문자 여부에 따라 캐시 히트가 되지 않는 경우가 존재 $\rightarrow$ 무조건 소문자 변환 해서 번역하도록 해 캐시 히트를 늘렸습니다. 